### PR TITLE
Remove header bottom line

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -104,7 +104,6 @@
 <style>
   .masthead {
     background-color: var(--masthead-bg, #212121);
-    border-bottom: 1px solid var(--hairline, rgba(128, 128, 128, 0.15));
     position: sticky;
     top: 0;
     z-index: 100;

--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -5,7 +5,6 @@
 .masthead {
   background-color: $background-color;
   position: relative;
-  border-bottom: 1px solid rgba($text-color, 0.1);
   -webkit-animation: intro 0.3s both;
           animation: intro 0.3s both;
   -webkit-animation-delay: 0.15s;


### PR DESCRIPTION
Removes the hairline under the masthead (it was set in two places: `_sass/_masthead.scss` and an inline style block in `_includes/masthead.html`). Verified in light + dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)